### PR TITLE
違法なコミットを規制する

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# 前のHEAD、新しいHEAD、そしてチェックアウトの種類（1 = 新しいブランチ、0 = 既存のブランチ）を取得
+previous_head=$1
+new_head=$2
+checkout_type=$3
+
+# 新しいブランチが作成された場合だけ origin/main をフェッチ
+if [ "$checkout_type" -eq 1 ]; then
+  git fetch origin main
+	if [ "$(git log --pretty=format:'%H' -n 1 main)" != "$(git log --pretty=format:'%H' -n 1 origin/main)" ]; then
+		echo -e "\033[31mWarning: Your local main is behind the remote one.\033[0m"
+	fi
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Check for files with credentials, excluding .env.example
+if git diff --cached --name-only | grep -E 'credentials|\.env' | grep -v '.env.example'; then
+    echo "Error: You have committed a file with credentials."
+    echo "Please remove the file and try again."
+    exit 1
+fi
+
+# コミット対象がmainだった場合にブロックする
+if git branch --show-current | grep -E 'main'; then
+    echo "Error: You have committed to main branch."
+    echo "Please commit to another branch and try again."
+    exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
 		"test:cov": "jest --coverage",
 		"test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
 		"test:e2e": "jest --config ./test/jest-e2e.json",
-		"submodule-update": "cd $(git rev-parse --show-superproject-working-tree --show-toplevel | head -1)/schema && git fetch && git checkout origin/main"
+		"submodule-update": "cd $(git rev-parse --show-superproject-working-tree --show-toplevel | head -1)/schema && git fetch && git checkout origin/main",
+		"setup-githooks": "git config core.hooksPath $(git rev-parse --show-superproject-working-tree --show-toplevel | head -1)/.githooks",
+		"postinstall": "yarn setup-githooks"
 	},
 	"engines": {
 		"npm": "use yarn instead.",


### PR DESCRIPTION
# やったこと

- 環境変数混入リスク低減
完全な混入阻止は期待できません。各々で確認しましょう。

<img width="564" alt="image" src="https://github.com/ih14c-13-14/artist-backend/assets/49822810/7a32c641-5446-4852-a369-72503b74f13e">

- mainへのコミット規制

<img width="565" alt="image" src="https://github.com/ih14c-13-14/artist-backend/assets/49822810/61967893-9c85-461e-902c-6d96d31c93ab">

- origin/mainより古いブランチからブランチ切ったら警告をだすように(失敗はさせない)
checkoutのたびに走ります。
毎回fetchするので時間かかるようになります。

![image](https://github.com/ih14c-13-14/artist-backend/assets/49822810/138a2fee-e730-468a-b916-38fbb57e3cf4)

# やらないこと
なし
