### PR TITLE
[hotfix] mainでghcr.ioへのpushがコケるのを修正

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,8 +7,8 @@ if git diff --cached --name-only | grep -E 'credentials|\.env' | grep -v '.env.e
     exit 1
 fi
 
-# コミット対象がmainだった場合にブロックする
-if git branch --show-current | grep -E 'main'; then
+# コミット対象が"main"で完全一致した場合にブロックする
+if git branch --show-current | grep -E '^main$'; then
     echo "Error: You have committed to main branch."
     echo "Please commit to another branch and try again."
     exit 1

--- a/.github/workflows/cd-for-main-push.yml
+++ b/.github/workflows/cd-for-main-push.yml
@@ -6,6 +6,11 @@ on:
       - master
     paths-ignore:
       - README.md
+
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   prepare:
     timeout-minutes: 60


### PR DESCRIPTION
# やったこと

1. 表題の通り
2. mainへのコミット規制で、mainという文字列が含まれてたらアウトになっていたのを修正
# やらないこと

# レビュー依頼前にやること

- [x] セルフレビューを行なった。
- [x] スペルミスがないことを確認した。
