### PR TITLE
CI上でerdモドキに差分が出たら落とす

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,5 @@ jobs:
         run: yarn prisma format && git diff --exit-code
       - name: DB Validate
         run: yarn prisma validate
+      - name: ERD check
+        run: yarn prisma generate && git diff --exit-code

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
# やったこと

Prismaスキーマいじった後にERD更新忘れたらCIで落とすように
ついでにnpm installしたらコケるように

# やらないこと

# レビュー依頼前にやること

- [x] セルフレビューを行なった。
- [x] スペルミスがないことを確認した。
